### PR TITLE
Move ROSTR card to top of experience page and update bullets

### DIFF
--- a/components/experience-content.tsx
+++ b/components/experience-content.tsx
@@ -21,7 +21,24 @@ function buildSections(): Section[] {
   const sections: Section[] = [];
   let sqInserted = false;
 
-  // Courses card first (personal, 2025)
+  const rostrRole = experience.find((r) => r.id === "rostr");
+  const selectQuoteRoles = experience.filter((r) => r.group === "selectquote");
+
+  // ROSTR first
+  if (rostrRole) {
+    sections.push({
+      id: rostrRole.id,
+      navLabel: rostrRole.navLabel,
+      category: rostrRole.category,
+      node: (
+        <div key={rostrRole.id} id={rostrRole.id} className="scroll-mt-24">
+          <RoleCard role={rostrRole} />
+        </div>
+      ),
+    });
+  }
+
+  // Courses card second
   sections.push({
     id: "courses",
     navLabel: "AI Training",
@@ -33,9 +50,9 @@ function buildSections(): Section[] {
     ),
   });
 
-  const selectQuoteRoles = experience.filter((r) => r.group === "selectquote");
-
   for (const role of experience) {
+    if (role.id === "rostr") continue;
+
     if (role.group === "selectquote") {
       if (!sqInserted) {
         sections.push({

--- a/lib/experience-data.ts
+++ b/lib/experience-data.ts
@@ -54,8 +54,7 @@ export const experience: Role[] = [
     navLabel: "ROSTR",
     category: "professional",
     bullets: [
-      "Owned end-to-end development of company's new web application and first iOS app, from architecture and design through App Store release. Achieved 100% adoption from existing Pro subscribers.",
-      "Leveraged cross-platform stack (Expo, React Native, React Native for Web, Tamagui) to maximize code reuse and efficiently ship both platforms",
+      "Designed and delivered the company's first iOS app and a new web platform, consolidating two products into one cross-platform codebase using Expo, React Native, and Tamagui.",
       "Modernized CI/CD pipelines with GitHub Actions and automated end-to-end testing using Maestro (iOS) and Playwright (web)",
       "Eliminated secrets sprawl and enhanced security by implementing HashiCorp Vault solution (GKE, Terraform, Helm) with OIDC-based authentication",
     ],


### PR DESCRIPTION
Place the ROSTR role card ahead of the AI Engineering Training
section. Consolidate the first two ROSTR bullet points into a
single, clearer description of the cross-platform work.

https://claude.ai/code/session_018TcxZQEB3R5Q7VoRbTd7yo